### PR TITLE
test fix

### DIFF
--- a/src/cognito-srp-helper.ts
+++ b/src/cognito-srp-helper.ts
@@ -108,15 +108,15 @@ export const createSecretHash = (username: string, clientId: string, secretId: s
   return secretHash;
 };
 
-export const createPasswordHash = (username: string, password: string, poolId: string): string => {
+export const createPasswordHash = (userId: string, password: string, poolId: string): string => {
   const poolIdAbbr = poolId.split("_")[1];
-  const usernamePassword = `${poolIdAbbr}${username}:${password}`;
+  const usernamePassword = `${poolIdAbbr}${userId}:${password}`;
   const passwordHash = hash(usernamePassword);
 
   return passwordHash;
 };
 
-export const createSrpSession = (username: string, passwordHash: string, poolId: string): SrpSession => {
+export const createSrpSession = (username: string, password: string, poolId: string, isHashed = true): SrpSession => {
   const poolIdAbbr = poolId.split("_")[1];
   const timestamp = createTimestamp();
   const smallA = generateSmallA();
@@ -124,8 +124,10 @@ export const createSrpSession = (username: string, passwordHash: string, poolId:
 
   return {
     username,
+    poolId,
     poolIdAbbr,
-    passwordHash,
+    password,
+    isHashed,
     timestamp,
     smallA: smallA.toString(16),
     largeA: largeA.toString(16),
@@ -139,8 +141,14 @@ export const signSrpSession = (session: SrpSession, response: InitiateAuthRespon
   if (!response.ChallengeParameters.SECRET_BLOCK) throw new MissingSecretError();
   if (!response.ChallengeParameters.SRP_B) throw new MissingLargeBError();
 
-  const { SALT: salt, SECRET_BLOCK: secret, SRP_B: largeB } = response.ChallengeParameters;
-  const { username, poolIdAbbr, passwordHash, timestamp, smallA, largeA } = session;
+  const {
+    SALT: salt,
+    SECRET_BLOCK: secret,
+    SRP_B: largeB,
+    USER_ID_FOR_SRP: userIdForSrp,
+  } = response.ChallengeParameters;
+  const { poolId, poolIdAbbr, password, isHashed, timestamp, smallA, largeA } = session;
+  const passwordHash = isHashed ? password : createPasswordHash(userIdForSrp, password, poolId);
 
   // Check server public key isn't 0
   if (largeB.replace(/^0+/, "") === "") throw new AbortOnZeroBSrpError();
@@ -154,7 +162,7 @@ export const signSrpSession = (session: SrpSession, response: InitiateAuthRespon
   const message = CryptoJS.lib.WordArray.create(
     Buffer.concat([
       Buffer.from(poolIdAbbr, "utf8"),
-      Buffer.from(username, "utf8"),
+      Buffer.from(userIdForSrp, "utf8"),
       Buffer.from(secret, "base64"),
       Buffer.from(timestamp, "utf8"),
     ]),

--- a/src/cognito-srp-helper.ts
+++ b/src/cognito-srp-helper.ts
@@ -101,8 +101,8 @@ const createTimestamp = (): string => {
   return `${weekDay} ${month} ${day} ${time} UTC ${year}`;
 };
 
-export const createSecretHash = (username: string, clientId: string, secretId: string): string => {
-  const hmac = CryptoJS.HmacSHA256(`${username}${clientId}`, secretId);
+export const createSecretHash = (userId: string, clientId: string, secretId: string): string => {
+  const hmac = CryptoJS.HmacSHA256(`${userId}${clientId}`, secretId);
   const secretHash = hmac.toString(CryptoJS.enc.Base64);
 
   return secretHash;

--- a/src/types.ts
+++ b/src/types.ts
@@ -171,8 +171,12 @@ export type Credentials = {
 export type SrpSession = {
   /** Username of the user. It is stored here for convenience when passing parameters into `computePasswordSignature` */
   username: string;
-  /** Password hash generated using the users credentials */
-  passwordHash: string;
+  /** Password used for authentication */
+  password: string;
+  /** Flag indicating whether the password has already been hashed */
+  isHashed: boolean;
+  /** Full un-abbreviated ID of the Cognito Userpool. Here it is the full ID that's used e.g. 'eu-west-2_abc123' */
+  poolId: string;
   /** Abbreviated ID of the Cognito Userpool. Here it is just the succeeding ID that's used e.g. 'eu-west-2_abc123' becomes 'abc123' */
   poolIdAbbr: string;
   /** Timestamp captured in the format requiree for Cogntio */


### PR DESCRIPTION
### With password hashing - users can only authenticate with Username (aka. user ID)

```js
const {
  createSrpSession,
  signSrpSession,
  wrapAuthChallenge,
  wrapInitiateAuth,
  createPasswordHash,
} = require("../cognito-srp-helper");
const {
  CognitoIdentityProviderClient,
  InitiateAuthCommand,
  RespondToAuthChallengeCommand,
} = require("@aws-sdk/client-cognito-identity-provider");

(async () => {
  const username = "a2c2e290-6d0f-4a08-a5ca-f0162935f3a6"; // this works
  // const username = "yorej57765@comsb.com"; // this won't work

  const password = "Qwerty1!";
  const poolId = "eu-west-2_eYpv1mFHB";
  const clientId = "18u8119jgbpr464n28s1itk2mq";
  const cognitoIdentityProviderClient = new CognitoIdentityProviderClient({
    region: "eu-west-2",
  });

  const passwordHash = createPasswordHash(username, password, poolId);
  const srpSession = createSrpSession(username, passwordHash, poolId);

  const initiateAuthRes = await cognitoIdentityProviderClient
    .send(
      new InitiateAuthCommand(
        wrapInitiateAuth(srpSession, {
          ClientId: clientId,
          AuthFlow: "USER_SRP_AUTH",
          AuthParameters: {
            CHALLENGE_NAME: "SRP_A",
            USERNAME: username,
          },
        })
      )
    )
    .catch((err) => {
      console.error(err);
      throw err;
    });

  console.log("initiateAuthRes:");
  console.log(initiateAuthRes);

  const signedSrpSession = signSrpSession(srpSession, initiateAuthRes);

  console.log("signedSrpSession:");
  console.log(signedSrpSession);

  const respondToAuthChallengeRes = await cognitoIdentityProviderClient
    .send(
      new RespondToAuthChallengeCommand(
        wrapAuthChallenge(signedSrpSession, {
          ClientId: clientId,
          ChallengeName: "PASSWORD_VERIFIER",
          ChallengeResponses: {
            USERNAME: username,
          },
        })
      )
    )
    .catch((err) => {
      console.error(err);
      throw err;
    });

  console.log("respondToAuthChallengeRes:");
  console.log(respondToAuthChallengeRes);
})();
```

### Without password hashing - users can authenticate with Username (aka. user ID), and email

```js
const {
  createSrpSession,
  signSrpSession,
  wrapAuthChallenge,
  wrapInitiateAuth,
} = require("../cognito-srp-helper");
const {
  CognitoIdentityProviderClient,
  InitiateAuthCommand,
  RespondToAuthChallengeCommand,
} = require("@aws-sdk/client-cognito-identity-provider");

(async () => {
  // const username = "a2c2e290-6d0f-4a08-a5ca-f0162935f3a6"; // this works
  const username = "yorej57765@comsb.com"; // and this works

  const password = "Qwerty1!";
  const poolId = "eu-west-2_eYpv1mFHB";
  const clientId = "18u8119jgbpr464n28s1itk2mq";
  const cognitoIdentityProviderClient = new CognitoIdentityProviderClient({
    region: "eu-west-2",
  });

  const srpSession = createSrpSession(username, password, poolId, false);

  const initiateAuthRes = await cognitoIdentityProviderClient
    .send(
      new InitiateAuthCommand(
        wrapInitiateAuth(srpSession, {
          ClientId: clientId,
          AuthFlow: "USER_SRP_AUTH",
          AuthParameters: {
            CHALLENGE_NAME: "SRP_A",
            USERNAME: username,
          },
        })
      )
    )
    .catch((err) => {
      console.error(err);
      throw err;
    });

  console.log("initiateAuthRes:");
  console.log(initiateAuthRes);

  const signedSrpSession = signSrpSession(srpSession, initiateAuthRes);

  console.log("signedSrpSession:");
  console.log(signedSrpSession);

  const respondToAuthChallengeRes = await cognitoIdentityProviderClient
    .send(
      new RespondToAuthChallengeCommand(
        wrapAuthChallenge(signedSrpSession, {
          ClientId: clientId,
          ChallengeName: "PASSWORD_VERIFIER",
          ChallengeResponses: {
            USERNAME: username,
          },
        })
      )
    )
    .catch((err) => {
      console.error(err);
      throw err;
    });

  console.log("respondToAuthChallengeRes:");
  console.log(respondToAuthChallengeRes);
})();
```