### PR TITLE
Reduce bundle size

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+### Context
+
+_TODO - specify the context around why this change is being made_
+
+### Changes
+
+_TODO - leave a quick summary / list of the changes here_
+
+### Testing
+
+_OPTIONAL - post any additional testing you've done here_

--- a/package.json
+++ b/package.json
@@ -34,8 +34,8 @@
   },
   "scripts": {
     "build": "npm run build:cjs && npm run build:esm && npm run build:types",
-    "build:cjs": "esbuild src/index.ts --bundle --format=cjs --outfile=dist/cjs/index.js && echo '{ \"type\": \"commonjs\" }' > dist/cjs/package.json",
-    "build:esm": "esbuild src/index.ts --bundle --format=esm --outfile=dist/esm/index.js && echo '{ \"type\": \"module\" }' > dist/esm/package.json",
+    "build:cjs": "esbuild src/index.ts --bundle --packages=external --minify --format=cjs --outfile=dist/cjs/index.js && echo '{ \"type\": \"commonjs\" }' > dist/cjs/package.json",
+    "build:esm": "esbuild src/index.ts --bundle --packages=external --minify  --format=esm --outfile=dist/esm/index.js && echo '{ \"type\": \"module\" }' > dist/esm/package.json",
     "build:types": "tsc --emitDeclarationOnly --declaration src/index.ts --esModuleInterop --outDir dist/types",
     "format": "npm run format:eslint && npm run format:prettier",
     "format:eslint": "eslint -c .eslintrc.cjs --fix src/**",


### PR DESCRIPTION
### Context

Noticed the bundle was unusually big (~720kb). Assumed it must be because it's a hybrid package, but looking into it, it looks like it's because npm dependencies are included in the bundle 🤦 . Minifying the bundle would also help reduce the size too. I've done both here

I've also added a PR template because why not

### Changes

- Exclude npm dependencies from bundle
- Minify bundle code
- Add PR template

### Testing

package size:  135.5 kB -> 16.4 kB
unpacked size: 721.7 kB -> 56.2 kB

Before:
```
simonmcallister@Simons-MBP cognito-srp-helper % npm publish --dry-run
npm WARN publish npm auto-corrected some errors in your package.json when publishing.  Please run "npm pkg fix" to address these errors.
npm WARN publish errors corrected:
npm WARN publish "repository" was changed from a string to an object
npm WARN publish "repository.url" was normalized to "git+https://github.com/simonmcallister0210/cognito-srp-helper.git"
npm notice 
npm notice 📦  cognito-srp-helper@2.3.0
npm notice === Tarball Contents === 
npm notice 10.9kB  LICENSE.md                        
npm notice 12.9kB  README.md                         
npm notice 342.8kB dist/cjs/index.js                 
npm notice 23B     dist/cjs/package.json             
npm notice 342.3kB dist/esm/index.js                 
npm notice 21B     dist/esm/package.json             
npm notice 1.2kB   dist/types/cognito-srp-helper.d.ts
npm notice 276B    dist/types/constants.d.ts         
npm notice 1.2kB   dist/types/errors.d.ts            
npm notice 89B     dist/types/index.d.ts             
npm notice 4.7kB   dist/types/types.d.ts             
npm notice 2.1kB   dist/types/utils.d.ts             
npm notice 3.1kB   package.json                      
npm notice === Tarball Details === 
npm notice name:          cognito-srp-helper                      
npm notice version:       2.3.0                                   
npm notice filename:      cognito-srp-helper-2.3.0.tgz            
npm notice package size:  135.5 kB                                
npm notice unpacked size: 721.7 kB                                
npm notice shasum:        5c016fcce82a27a899d89ef1d0b525a0c4b0767c
npm notice integrity:     sha512-BtAJOB/4Uxldo[...]BgSSuPXrUJKHQ==
npm notice total files:   13                                      
npm notice 
npm notice Publishing to https://registry.npmjs.org/ with tag latest and default access (dry-run)
+ cognito-srp-helper@2.3.0
```

After:
```
simonmcallister@Simons-MBP cognito-srp-helper % npm publish --dry-run                            
npm WARN publish npm auto-corrected some errors in your package.json when publishing.  Please run "npm pkg fix" to address these errors.
npm WARN publish errors corrected:
npm WARN publish "repository" was changed from a string to an object
npm WARN publish "repository.url" was normalized to "git+https://github.com/simonmcallister0210/cognito-srp-helper.git"
npm notice 
npm notice 📦  cognito-srp-helper@2.3.0
npm notice === Tarball Contents === 
npm notice 10.9kB LICENSE.md                        
npm notice 12.9kB README.md                         
npm notice 10.4kB dist/cjs/index.js                 
npm notice 23B    dist/cjs/package.json             
npm notice 9.3kB  dist/esm/index.js                 
npm notice 21B    dist/esm/package.json             
npm notice 1.2kB  dist/types/cognito-srp-helper.d.ts
npm notice 276B   dist/types/constants.d.ts         
npm notice 1.2kB  dist/types/errors.d.ts            
npm notice 89B    dist/types/index.d.ts             
npm notice 4.7kB  dist/types/types.d.ts             
npm notice 2.1kB  dist/types/utils.d.ts             
npm notice 3.1kB  package.json                      
npm notice === Tarball Details === 
npm notice name:          cognito-srp-helper                      
npm notice version:       2.3.0                                   
npm notice filename:      cognito-srp-helper-2.3.0.tgz            
npm notice package size:  16.4 kB                                 
npm notice unpacked size: 56.2 kB                                 
npm notice shasum:        268e91bf90db5f7e8beb2f577ce79d6df9d0ce14
npm notice integrity:     sha512-ZXLJ1A3iM8Eo7[...]Mxqwalpf96OuA==
npm notice total files:   13                                      
npm notice 
npm notice Publishing to https://registry.npmjs.org/ with tag latest and default access (dry-run)
+ cognito-srp-helper@2.3.0
```