### PR TITLE
Fix for users using NodeNext TS Module

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cognito-srp-helper",
-  "version": "2.3.2",
+  "version": "2.3.1",
   "description": "A helper for SRP authentication in AWS Cognito",
   "author": "Simon McAllister",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cognito-srp-helper",
-  "version": "2.3.1",
+  "version": "2.3.2-beta-v1",
   "description": "A helper for SRP authentication in AWS Cognito",
   "author": "Simon McAllister",
   "license": "Apache-2.0",
@@ -36,7 +36,7 @@
     "build": "npm run build:cjs && npm run build:esm && npm run build:types",
     "build:cjs": "esbuild src/index.ts --bundle --packages=external --minify --format=cjs --outfile=dist/cjs/index.js && echo '{ \"type\": \"commonjs\" }' > dist/cjs/package.json",
     "build:esm": "esbuild src/index.ts --bundle --packages=external --minify  --format=esm --outfile=dist/esm/index.js && echo '{ \"type\": \"module\" }' > dist/esm/package.json",
-    "build:types": "tsc --emitDeclarationOnly --declaration src/index.ts --esModuleInterop --outDir dist/types",
+    "build:types": "tsc --emitDeclarationOnly --declaration src/index.ts --esModuleInterop --outFile dist/types/index.d.ts",
     "format": "npm run format:eslint && npm run format:prettier",
     "format:eslint": "eslint -c .eslintrc.cjs --fix src/**",
     "format:prettier": "prettier -c .prettierrc.cjs --write src/**",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cognito-srp-helper",
-  "version": "2.3.2-beta-v1",
+  "version": "2.3.2",
   "description": "A helper for SRP authentication in AWS Cognito",
   "author": "Simon McAllister",
   "license": "Apache-2.0",


### PR DESCRIPTION
### Context

Users using the NodeNext in their `tsconfig.json` file noticed issues importing from the package. Errors like:

> Module 'cognito-srp-helper' has no exported member 'createSrpSession'

Looking inside the dist/types folder they noticed this type error:

> Relative import paths need explicit file extensions in ECMAScript imports when '--moduleResolution' is 'node16' or 'nodenext'. Consider adding an extension to the import path.
> 
> 1 export * from "./cognito-srp-helper";

Using a single declaration file would fix this, because it removes the need for any import statements. For this fix we're tweaking the type build to output a single file `index.d.ts`

### Changes

Tweak `build:types` script to output single declaration file `index.d.ts`

### Testing

Before:
![Screenshot 2024-12-01 at 20 39 49](https://github.com/user-attachments/assets/04b8087b-2d49-46c3-8b48-29c6944d7a1b)

After:
![Screenshot 2024-12-01 at 20 42 26](https://github.com/user-attachments/assets/8b21b289-8d60-4925-a104-e52a11fd4d0a)


