### PR TITLE
Make internal imports more friendly for users using ES Modules

### DIFF
--- a/src/cognito-srp-helper.ts
+++ b/src/cognito-srp-helper.ts
@@ -1,4 +1,4 @@
-import { Buffer } from "buffer/"; // use the browser compatible buffer library
+import { Buffer } from "buffer/index.js"; // use the browser compatible buffer library
 import CryptoJS from "crypto-js";
 import { BigInteger } from "jsbn";
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,4 +1,4 @@
-import { Buffer } from "buffer/"; // use the browser compatible buffer library
+import { Buffer } from "buffer/index.js"; // use the browser compatible buffer library
 import { BigInteger } from "jsbn";
 
 import { hexHash, padHex } from "./utils";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,13 @@
+import * as CognitoSrpHelper from "./cognito-srp-helper";
+import * as Errors from "./errors";
+import * as Types from "./types";
+
 export * from "./cognito-srp-helper";
 export * from "./errors";
 export * from "./types";
+
+export default {
+  ...CognitoSrpHelper,
+  ...Errors,
+  ...Types,
+};

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { Buffer } from "buffer/"; // use the browser compatible buffer library
-import { lib, SHA256 } from "crypto-js";
+import { Buffer } from "buffer/index.js"; // use the browser compatible buffer library
+import CryptoJS from "crypto-js";
 import { BigInteger } from "jsbn";
 
 import { HEX_TO_SHORT } from "./constants";
@@ -16,8 +16,8 @@ import { HEX_TO_SHORT } from "./constants";
  * @returns Hex-encoded hash.
  */
 export const hash = (buf: Buffer | string): string => {
-  const str = buf instanceof Buffer ? lib.WordArray.create(buf) : buf;
-  const hashHex = SHA256(str).toString();
+  const str = buf instanceof Buffer ? CryptoJS.lib.WordArray.create(buf) : buf;
+  const hashHex = CryptoJS.SHA256(str).toString();
   const completeHash = new Array(64 - hashHex.length).join("0") + hashHex;
 
   return completeHash;
@@ -118,7 +118,7 @@ export const padHex = (bigInt: BigInteger): string => {
  * @returns Fixed-length sequence of random bytes
  */
 export const randomBytes = (nBytes: number): Buffer => {
-  const bytes = Buffer.from(lib.WordArray.random(nBytes).toString(), "hex");
+  const bytes = Buffer.from(CryptoJS.lib.WordArray.random(nBytes).toString(), "hex");
 
   return bytes;
 };


### PR DESCRIPTION
### Context

A user noticed an error when trying to import the package when using ES Modules:

```
Error [ERR_UNSUPPORTED_DIR_IMPORT]: Directory import '/project/node_modules/.pnpm/cognito-srp-helper@2.3.2/node_modules/buffer/' is not supported resolving ES modules imported from /project/node_modules/.pnpm/cognito-srp-helper@2.3.2/node_modules/cognito-srp-helper/dist/esm/index.js
Did you mean to import buffer@6.0.3/node_modules/buffer/index.js?
    at finalizeResolution (node:internal/modules/esm/resolve:249:11)
    at moduleResolve (node:internal/modules/esm/resolve:908:10)
    at defaultResolve (node:internal/modules/esm/resolve:1121:11)
    at ModuleLoader.defaultResolve (node:internal/modules/esm/loader:396:12)
    at ModuleLoader.resolve (node:internal/modules/esm/loader:365:25)
    at ModuleLoader.getModuleJob (node:internal/modules/esm/loader:240:38)
    at ModuleWrap.<anonymous> (node:internal/modules/esm/module_job:85:39)
    at link (node:internal/modules/esm/module_job:84:36) {
  code: 'ERR_UNSUPPORTED_DIR_IMPORT',
  url: 'file:///project/node_modules/.pnpm/cognito-srp-helper@2.3.2/node_modules/buffer/'
```

We're using the buffer package so that our package can work in both NodeJS and browsers. To "tell" the code to import this version of Buffer, and not the built-in version, you have to import it via a directory and not the package name. Importing from `buffer/` is problematic, but `buffer/index.js` is fine

Whilst fixing this issue I noticed it had a problem with me import `{ lib, ... }` from crypto-js. Using the default import fixed that

And finally I also noticed the package doesn't have a default export, so I added that too

### Changes

- Make `buffer` imports more explicit
- Use default import for `crypto-js`
- Provide a default export

### Testing

@wingy3181 kindly provided a [repo to replicate the issue](https://github.com/wingy3181/cognito-srp-helper-issue-52), along with some test cases. Here's the test cases succeeding with the modified version of the package:

![Screenshot 2025-02-01 at 22 10 26](https://github.com/user-attachments/assets/d381e2f0-1fff-40c9-b74a-8f7a0af2d913)

