### PR TITLE
fix: rollback fast-xml-parse from `4.4.1` to `4.3.4` to fix high security vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -432,6 +432,27 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/@aws-sdk/core/node_modules/fast-xml-parser": {
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.3.5.tgz",
+      "integrity": "sha512-sWvP1Pl8H03B8oFJpFR3HE31HUfwtX7Rlf9BNsvdpujD4n7WMhfmu8h9wOV2u+c1k0ZilTADhPqypzx2J690ZQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/naturalintelligence"
+        }
+      ],
+      "dependencies": {
+        "strnum": "^1.0.5"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
     "node_modules/@aws-sdk/core/node_modules/tslib": {
       "version": "2.6.3",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
@@ -5254,27 +5275,6 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true
     },
-    "node_modules/fast-xml-parser": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.4.1.tgz",
-      "integrity": "sha512-xkjOecfnKGkSsOwtZ5Pz7Us/T6mrbPQrq0nh+aCO5V9nk5NLWmasAHumTKjiPJPWANe+kAZ84Jc8ooJkzZ88Sw==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/NaturalIntelligence"
-        },
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/naturalintelligence"
-        }
-      ],
-      "dependencies": {
-        "strnum": "^1.0.5"
-      },
-      "bin": {
-        "fxparser": "src/cli/cli.js"
-      }
-    },
     "node_modules/fastq": {
       "version": "1.14.0",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.14.0.tgz",
@@ -9222,10 +9222,17 @@
         "@smithy/smithy-client": "^3.1.12",
         "@smithy/types": "^3.3.0",
         "@smithy/util-middleware": "^3.0.3",
-        "fast-xml-parser": "4.4.1",
+        "fast-xml-parser": "4.3.4",
         "tslib": "^2.6.2"
       },
       "dependencies": {
+        "fast-xml-parser": {
+          "version": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.3.5.tgz",
+          "integrity": "sha512-sWvP1Pl8H03B8oFJpFR3HE31HUfwtX7Rlf9BNsvdpujD4n7WMhfmu8h9wOV2u+c1k0ZilTADhPqypzx2J690ZQ==",
+          "requires": {
+            "strnum": "^1.0.5"
+          }
+        },
         "tslib": {
           "version": "2.6.3",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
@@ -12880,14 +12887,6 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true
-    },
-    "fast-xml-parser": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.4.1.tgz",
-      "integrity": "sha512-xkjOecfnKGkSsOwtZ5Pz7Us/T6mrbPQrq0nh+aCO5V9nk5NLWmasAHumTKjiPJPWANe+kAZ84Jc8ooJkzZ88Sw==",
-      "requires": {
-        "strnum": "^1.0.5"
-      }
     },
     "fastq": {
       "version": "1.14.0",

--- a/package.json
+++ b/package.json
@@ -87,5 +87,8 @@
     "buffer": "^6.0.3",
     "crypto-js": "4.2.0",
     "jsbn": "1.1.0"
+  },
+  "overrides": {
+    "fast-xml-parser": "4.3.4"
   }
 }


### PR DESCRIPTION
### Context

Github flagged a high level security vulnerability, via AWS Cognito > fast-xml-parse

We can't fix it by updating the AWS dependency, and we can't it by overriding to a later patch of fast-xml-parse

The best we can do is rollback `fast-xml-parse` a few minor and patch numbers to reach an unaffected version of the package

### Changes

Override `fast-xml-parse` from 4.4.1 to 4.3.4
