### PR TITLE
Run tests on PR

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         # https://nodejs.org/en/about/previous-releases#release-schedule
         node-version: [20, 22, 24, 25] # remember to update this when support is added/dropped

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         # https://nodejs.org/en/about/previous-releases#release-schedule
-        node-version: [18, 20] # remember to update this when support is added/dropped
+        node-version: [20, 22, 24, 25] # remember to update this when support is added/dropped
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
-      - run: npm ci
+      - run: npm install
       - run: npm run lint
       - run: npm run build
       - run: npm run test:unit

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,12 @@
 name: test
 
 on:
+  pull_request:
+    branches:
+      - "main"
   push:
+    branches:
+      - "main"
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         # https://nodejs.org/en/about/previous-releases#release-schedule
-        node-version: [20, 22, 24, 25] # remember to update this when support is added/dropped
+        node-version: [20, 22, 24] # remember to update this when support is added/dropped
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,14 +15,14 @@ jobs:
     strategy:
       matrix:
         # https://nodejs.org/en/about/previous-releases#release-schedule
-        node-version: [20, 22, 24] # remember to update this when support is added/dropped
+        node-version: [20, 22, 24, 25] # remember to update this when support is added/dropped
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
-      - run: npm ci
+      - run: npm install
       - run: npm run lint
       - run: npm run build
       - run: npm run test:unit

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         # https://nodejs.org/en/about/previous-releases#release-schedule
-        node-version: [18, 20] # remember to update this when support is added/dropped
+        node-version: [20, 22, 24, 25] # remember to update this when support is added/dropped
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         # https://nodejs.org/en/about/previous-releases#release-schedule
         node-version: [20, 22, 24, 25] # remember to update this when support is added/dropped

--- a/src/__tests__/integration/sdk-v2-device-flow.test.ts
+++ b/src/__tests__/integration/sdk-v2-device-flow.test.ts
@@ -382,7 +382,7 @@ describe("SDK v2 integration - DEVICE_SRP_AUTH flow", () => {
         expect(respondToAuthChallengeRes3c.AuthenticationResult).toHaveProperty("AccessToken");
         expect(respondToAuthChallengeRes3c.AuthenticationResult).toHaveProperty("RefreshToken");
       },
-      1000 * 35 /* 35 seconds = 30 seconds to account for OTP expiration + 5 seconds for standard timeout */,
+      1000 * 65 /* 65 seconds = 30 seconds to account for OTP expiration + 5 seconds for standard timeout */,
     );
   });
 
@@ -662,7 +662,7 @@ describe("SDK v2 integration - DEVICE_SRP_AUTH flow", () => {
         expect(respondToAuthChallengeRes3c.AuthenticationResult).toHaveProperty("AccessToken");
         expect(respondToAuthChallengeRes3c.AuthenticationResult).toHaveProperty("RefreshToken");
       },
-      1000 * 35 /* 35 seconds = 30 seconds to account for OTP expiration + 5 seconds for standard timeout */,
+      1000 * 65 /* 65 seconds = 30 seconds to account for OTP expiration + 5 seconds for standard timeout */,
     );
   });
 });

--- a/src/__tests__/integration/sdk-v3-device-flow.test.ts
+++ b/src/__tests__/integration/sdk-v3-device-flow.test.ts
@@ -388,7 +388,7 @@ describe("SDK v3 integration - DEVICE_SRP_AUTH flow", () => {
         expect(respondToAuthChallengeRes3c.AuthenticationResult).toHaveProperty("AccessToken");
         expect(respondToAuthChallengeRes3c.AuthenticationResult).toHaveProperty("RefreshToken");
       },
-      1000 * 35 /* 35 seconds = 30 seconds to account for OTP expiration + 5 seconds for standard timeout */,
+      1000 * 65 /* 65 seconds = 30 seconds to account for OTP expiration + 5 seconds for standard timeout */,
     );
   });
 
@@ -667,7 +667,7 @@ describe("SDK v3 integration - DEVICE_SRP_AUTH flow", () => {
         expect(respondToAuthChallengeRes3c.AuthenticationResult).toHaveProperty("AccessToken");
         expect(respondToAuthChallengeRes3c.AuthenticationResult).toHaveProperty("RefreshToken");
       },
-      1000 * 35 /* 35 seconds = 30 seconds to account for OTP expiration + 5 seconds for standard timeout */,
+      1000 * 65 /* 65 seconds = 30 seconds to account for OTP expiration + 5 seconds for standard timeout */,
     );
   });
 });


### PR DESCRIPTION
### Context

We should be running tests and checks on PR

I noticed tests are timing out on v22+. I think this has something with to do with [big-integer](https://github.com/simonmcallister0210/cognito-srp-helper/issues/33#issuecomment-2465262332), and possibly the "...Long" test cases being consumed from [here](https://github.com/simonmcallister0210/cognito-srp-helper/blob/0eb942b19c295ba28f3b9f99ff3f21bde429cc22/src/__tests__/test-cases/initiate-auth-response.ts).

There's a refactor for big integer going on atm which might fix the issue. So I'll merge this PR in, despite the failing tests

### Changes

- Update node versions to matrix (20, 22, 24, 25)
- Extend some integration test time outs from 35s to 65s
- Disable fast-fail on tests
